### PR TITLE
Feat: Implement UI for API key input and integrate with AI features

### DIFF
--- a/src/components/ChatAssistant.tsx
+++ b/src/components/ChatAssistant.tsx
@@ -12,7 +12,8 @@ import { useToast } from '@/hooks/use-toast';
 
 
 interface ChatAssistantProps {
-  content: string; // This is fullText from EnhancedPDFResult
+  apiKey: string; // Added apiKey prop
+  content: string;
   pdfResult: EnhancedPDFResult | null;
 }
 
@@ -23,7 +24,7 @@ interface Message {
   timestamp: Date;
 }
 
-const ChatAssistant = ({ content, pdfResult }: ChatAssistantProps) => {
+const ChatAssistant = ({ apiKey, content, pdfResult }: ChatAssistantProps) => {
   const [messages, setMessages] = useState<Message[]>([
     {
       id: '1',
@@ -61,16 +62,27 @@ const ChatAssistant = ({ content, pdfResult }: ChatAssistantProps) => {
     setIsLoading(true);
     setChatProgress({ value: 0, message: "Sending..." });
 
-    // API Key should be passed from props/context in a real app
-    // For now, it's read from geminiApi.ts (which is bad practice for production)
-    // This component itself doesn't know the key, it's an argument to chatWithContent
-    const apiKeyFromSomewhere = "NEEDS_TO_BE_PASSED_IN_OR_FROM_CONTEXT"; // Placeholder
+    if (!apiKey) {
+      const errorResponseMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        type: 'assistant',
+        content: "API Key is missing. Please set it on the home page to use the chat assistant.",
+        timestamp: new Date()
+      };
+      setMessages(prev => [...prev, errorResponseMessage]);
+      setIsLoading(false);
+      setChatProgress(null);
+      toast({
+        title: "API Key Missing",
+        description: "Please provide a Gemini API key to use the chat assistant.",
+        variant: "destructive",
+      });
+      return;
+    }
 
     try {
-      // TODO: Replace "apiKeyFromSomewhere" with the actual API key from app state/context
-      // For now, this will cause an error if not manually updated in the local geminiApi.ts or passed correctly
       const assistantResponseText = await chatWithContent(
-        apiKeyFromSomewhere, // This needs to be sourced correctly
+        apiKey, // Use the apiKey prop
         content,
         userMessage.content,
         (progress) => setChatProgress(progress)

--- a/src/components/ExamGenerator.tsx
+++ b/src/components/ExamGenerator.tsx
@@ -13,12 +13,13 @@ import { generateQuestions, GeminiQuestion, QuestionGenerationRequest } from '@/
 import { Progress } from '@/components/ui/progress'; // For showing generation progress
 
 interface ExamGeneratorProps {
-  content: string; // This is fullText from EnhancedPDFResult
-  pdfResult: EnhancedPDFResult | null; // Changed from PDFExtractionResult
-  onStartExam: (questions: GeminiQuestion[], timeLimitMinutes: number) => void; // Modified to pass questions
+  apiKey: string; // Added apiKey prop
+  content: string;
+  pdfResult: EnhancedPDFResult | null;
+  onStartExam: (questions: GeminiQuestion[], timeLimitMinutes: number) => void;
 }
 
-const ExamGenerator = ({ content, pdfResult, onStartExam }: ExamGeneratorProps) => {
+const ExamGenerator = ({ apiKey, content, pdfResult, onStartExam }: ExamGeneratorProps) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [generationProgress, setGenerationProgress] = useState<{value: number, message: string} | null>(null);
   const [mcqCount, setMcqCount] = useState([5]);
@@ -80,8 +81,20 @@ const ExamGenerator = ({ content, pdfResult, onStartExam }: ExamGeneratorProps) 
       difficulty: difficulty as 'basic' | 'intermediate' | 'advanced',
     };
 
+    if (!apiKey) {
+      toast({
+        title: "API Key Missing",
+        description: "Please provide a Gemini API key in the settings on the home page.",
+        variant: "destructive",
+      });
+      setIsGenerating(false);
+      setGenerationProgress(null);
+      return;
+    }
+
     try {
       const generatedQuestions = await generateQuestions(
+        apiKey, // Pass the apiKey
         request.content,
         request,
         (progress) => setGenerationProgress(progress)


### PR DESCRIPTION
- Added an API key input field in `Index.tsx`.
  - The key is stored in `localStorage` for session convenience.
  - `geminiApiKey` state is passed as a prop to `ExamGenerator` and `ChatAssistant`.
  - Feature cards on the home page are conditionally disabled based on API key and PDF content presence.
- Updated `ExamGenerator.tsx` to receive and use the `apiKey` prop.
  - Includes a check and toast if the API key is missing.
- Updated `ChatAssistant.tsx` to receive and use the `apiKey` prop.
  - Includes a check and displays an error in chat/toast if the API key is missing.
- Updated the test plan to cover this new API key input mechanism.